### PR TITLE
Check exit code

### DIFF
--- a/tasks/shell.js
+++ b/tasks/shell.js
@@ -58,8 +58,11 @@ module.exports = function( grunt ) {
 
 
         proc.on('exit', function (code) {
-            if ( _.isFunction( data.callback ) )
+            if ( _.isFunction( data.callback ) ) {
                 data.callback.call(this);
+            } else if ( 0 !== code ){
+                grunt.warn("Done, with errors.", 3);
+            }
             done();
         });
 


### PR DESCRIPTION
When a command exits with a code other than 0 grunt needs to warn us, this allows us to use --force to ignore them if we want to.
