### PR TITLE
Run tests and lint with npm test

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -9,6 +9,5 @@
   "undef": true,
   "boss": true,
   "eqnull": true,
-  "node": true,
-  "es5": true
+  "node": true
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -46,7 +46,7 @@ module.exports = function(grunt) {
                         setTimeout(function() { cb(); }, 5000);
                     }
                 }
-            }, 
+            },
 
             syncWithCallbacks: {
                 command: 'sleep 3 & echo HELLO & sleep 1 & echo WORLD & sleep 2',
@@ -87,15 +87,15 @@ module.exports = function(grunt) {
         },
 
         nodeunit: {
-            tests: ['test/*_test.js']
+            tests: ['tests/*_test.js']
         }
 
     });
 
     grunt.loadTasks('tasks');
 
-    //grunt.loadNpmTasks('grunt-contrib-jshint');
-    //grunt.loadNpmTasks('grunt-contrib-nodeunit');
+    grunt.loadNpmTasks('grunt-contrib-jshint');
+    grunt.loadNpmTasks('grunt-contrib-nodeunit');
 
     grunt.registerTask('wait', function() {
         this.async();

--- a/package.json
+++ b/package.json
@@ -1,47 +1,59 @@
 {
-	"name": "grunt-shell-spawn",
-	"version": "0.3.0",
-	"description": "Grunt task to run shell commands",
-	"keywords": [
-		"gruntplugin",
-		"grunt",
-		"shell",
-		"command",
-		"exec",
-		"spawn",
-		"cli"
-	],
-	"homepage": "https://github.com/cri5ti/grunt-shell-spawn",
-	"bugs": "https://github.com/cri5ti/grunt-shell-spawn/issues",
-	"author": {
-		"name": "Sindre Sorhus",
-		"email": "sindresorhus@gmail.com",
-		"url": "http://sindresorhus.com"
-	},
-	"contributors": [{
-		"name": "Cristi Mihai",
-		"email": "cristi.mihai@gmail.com",
-		"url": "https://github.com/cri5ti"
-	}, {
-		"name": "Friedel Ziegelmayer",
-		"url": "https://github.com/Dignifiedquire"
-	}, {
-		"name": "Trevor Landau",
-		"url": "https://github.com/landau"
-	}],
-	"main": "grunt.js",
-	"bin": "bin/grunt-shell-spawn",
-	"repository": {
-		"type": "git",
-		"url": "git://github.com/cri5ti/grunt-shell-spawn.git"
-	},
-	"dependencies": {
-		"grunt": ">=0.4.x"
-	},
-	"engines": {
-		"node": ">=0.6.0"
-	},
-	"licenses": {
-		"type": "MIT"
-	}
+  "name": "grunt-shell-spawn",
+  "version": "0.3.0",
+  "description": "Grunt task to run shell commands",
+  "keywords": [
+    "gruntplugin",
+    "grunt",
+    "shell",
+    "command",
+    "exec",
+    "spawn",
+    "cli"
+  ],
+  "homepage": "https://github.com/cri5ti/grunt-shell-spawn",
+  "bugs": "https://github.com/cri5ti/grunt-shell-spawn/issues",
+  "author": {
+    "name": "Sindre Sorhus",
+    "email": "sindresorhus@gmail.com",
+    "url": "http://sindresorhus.com"
+  },
+  "contributors": [
+    {
+      "name": "Cristi Mihai",
+      "email": "cristi.mihai@gmail.com",
+      "url": "https://github.com/cri5ti"
+    },
+    {
+      "name": "Friedel Ziegelmayer",
+      "url": "https://github.com/Dignifiedquire"
+    },
+    {
+      "name": "Trevor Landau",
+      "url": "https://github.com/landau"
+    }
+  ],
+  "main": "grunt.js",
+  "bin": "bin/grunt-shell-spawn",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/cri5ti/grunt-shell-spawn.git"
+  },
+  "dependencies": {
+    "grunt": ">=0.4.x"
+  },
+  "devDependencies": {
+    "grunt-cli": "~0.1.9",
+    "grunt-contrib-jshint": "~0.7.0",
+    "grunt-contrib-nodeunit": "~0.2.2"
+  },
+  "scripts": {
+    "test": "grunt jshint nodeunit"
+  },
+  "engines": {
+    "node": ">=0.6.0"
+  },
+  "licenses": {
+    "type": "MIT"
+  }
 }

--- a/tests/shell_spawn_test.js
+++ b/tests/shell_spawn_test.js
@@ -1,0 +1,17 @@
+'use strict';
+
+var grunt = require('grunt');
+var fs = require('fs');
+var exec = require('child_process').exec;
+
+exports.stylus = {
+  defaultSync: function(test) {
+    test.expect(2);
+
+    exec('./node_modules/.bin/grunt shell:defaultSync', function(error, stdout, stderr) {
+      test.equal(error, null, 'It should not error');
+      test.equal(stderr, '', 'It should not error');
+      test.done();
+    });
+  }
+};


### PR DESCRIPTION
Looks like jshint and nodeunit were half integrated.  I couldn't find a one-liner to run automated tests.  This PR wires up `npm test` (used by TravisCI & friends) to `grunt jshint` and `grunt nodeunit`.  I added in the nodeunit and jshint dev dependencies and started a test file, `shell_spawn_test.js`, to hook into the `shell` targets defined in the Gruntfile.  I didn't hook up all the targets yet, waiting for confirmation that folks like this direction. 
