### PR TITLE
Don't convert forward slashes to backslashes on Windows

### DIFF
--- a/tasks/shell.js
+++ b/tasks/shell.js
@@ -51,7 +51,7 @@ module.exports = function( grunt ) {
 
         if (process.platform === 'win32') {
             file = 'cmd.exe';
-            args = ['/s', '/c', data.command.replace(/\//g, '\\') ];
+            args = ['/s', '/c', data.command ];
             opts.windowsVerbatimArguments = true;
         } else {
             file = '/bin/sh';


### PR DESCRIPTION
This fixes #12

It's best to leave this path normalization up to the user.  As was mentioned in a similar issue upstream, commands can have way more things than just paths in them.  Examples include URLs, and Windows-style /arguments.