### PR TITLE
Fix for capturing stderr properly (#15)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -66,6 +66,28 @@ module.exports = function(grunt) {
                 }
             },
 
+            testProcessSync: {
+                command: 'node tests/process/process.js',
+                options: {
+                    async: false,
+                    callback: function (code, out, err, cb) {
+                        validateTestProcessOutput(code, out, err);
+                        cb();
+                    }
+                }
+            },
+
+            testProcessAsync: {
+                command: 'node tests/process/process.js',
+                options: {
+                    async: true,
+                    callback: function (code, out, err, cb) {
+                        validateTestProcessOutput(code, out, err);
+                        cb();
+                    }
+                }
+            },
+
             neverEndingTask: {
                 command: 'node tests/server/server.js',
                 options: {
@@ -96,6 +118,25 @@ module.exports = function(grunt) {
 
     });
 
+    function validateTestProcessOutput(code, out, err) {
+        // Validates expected stdout, stderr, and exit code of the test process at
+        // tests/process/process.js. If any of them fail, print an error message in stderr (so that
+        // the error can be seen when running tests - the grunt.fatal message does not get emitted),
+        // and stop grunt.
+        if (out !== 'This should appear in stdout\n') {
+            console.error('stdout did not match. Got:"' + out + '"');
+            grunt.fatal('stdout did not match');
+        }
+        if (err !== 'This should appear in stderr\n') {
+            console.error('stderr did not match. Got:"' + err + '"');
+            grunt.fatal('stderr did not match');
+        }
+        if (code !== 117) {
+            console.error('Exit code did not match. Expected 117, got: ' + code + '.');
+            grunt.fatal('exit code did not match');
+        }
+    }
+
     grunt.loadTasks('tasks');
 
     grunt.loadNpmTasks('grunt-contrib-jshint');
@@ -113,4 +154,6 @@ module.exports = function(grunt) {
     grunt.registerTask('killTask', ['shell:neverEndingTask', 'shell:curl', 'shell:neverEndingTask:kill']);
 
     grunt.registerTask('repeat', ['shell:echo', 'shell:echo']);
+
+    grunt.registerTask('testProcessAsync', ['shell:testProcessAsync', 'wait:2']);
 };

--- a/tasks/shell.js
+++ b/tasks/shell.js
@@ -115,7 +115,7 @@ module.exports = function( grunt ) {
             delete procs[target];
             if ( _.isFunction( options.callback ) ) {
                 var stdOutString = stdOutBuf.toString('utf8', 0, stdOutPos),
-                    stdErrString = stdOutBuf.toString('utf8', 0, stdErrPos);
+                    stdErrString = stdErrBuf.toString('utf8', 0, stdErrPos);
 
                 options.callback.call(this, code, stdOutString, stdErrString, done);
             } else if ( 0 !== code && options.failOnError ){

--- a/tests/process/process.js
+++ b/tests/process/process.js
@@ -1,0 +1,3 @@
+process.stdout.write('This should appear in stdout\n');
+process.stderr.write('This should appear in stderr\n');
+process.exit(117);	// Exit with code 117

--- a/tests/shell_spawn_test.js
+++ b/tests/shell_spawn_test.js
@@ -26,5 +26,23 @@ exports['grunt-shell-spawn'] = {
       shouldNotError(test, error, stderr);
       test.done();
     });
+  },
+
+  'Captures stdout, stderr, and exit code of synchronous process': function (test) {
+    test.expect(2);
+
+    exec('./node_modules/.bin/grunt shell:testProcessSync', function(error, stdout, stderr) {
+      shouldNotError(test, error, stderr);
+      test.done();
+    });
+  },
+
+  'Captures stdout, stderr, and exit code of async process': function (test) {
+    test.expect(2);
+
+    exec('./node_modules/.bin/grunt testProcessAsync', function(error, stdout, stderr) {
+      shouldNotError(test, error, stderr);
+      test.done();
+    });
   }
 };


### PR DESCRIPTION
Added some tests as well to make sure we're properly capturing stdout, stderr, and the exit code of both synchronous and asynchronous processes.

Some notes follow:

There's an unfortunate issue with error reporting that I noticed. Any message passed to grunt.fatal() isn't visible in the output of a failing test when running `npm test`.  It just says "Error: Command failed:", and nothing else.  I tried a bunch of things, but couldn't figure out a better way than what I'm currently doing, which is printing the error message using console.error(), and then calling grunt.fatal().  It's a bit repetitive, but at least the message shows up.

Also, there was a `wait` task which appeared to be unused (let me know if this is not correct). I decided to make better use of it by making it able to take a parameter representing the number of seconds to wait. This can be used for testing some of the async functionality by just including it as one of the tasks. For instance, I'm using it for the async test case to keep grunt running after launching the async process (as otherwise grunt just exits immediately):

```
grunt.registerTask('testProcessAsync', ['shell:testProcessAsync', 'wait:2']);
```
