### PR TITLE
Adding support for stopping process if already started.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grunt-shell-spawn",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Grunt task to run shell commands",
   "keywords": [
     "gruntplugin",


### PR DESCRIPTION
My use case is this:

- There is an http server that depend on several sources;
- The sources are watched with grunt-contrib-watch;
- I want to restart the server if any source changes;
- I want to avoid killing the server with SIGKILL so it can exit properly.

What I did:

- Allow a shell sub task to be called more than one time, if a process exists it will be killed (with SIGTERM);
- Add an option to enable that, defaulting to the old (and expected) behaviour.

I changed the minor version, but in retrospection I should have changed the middle one since it's a feature.

I didn't take the time to write a test, sorry.

If there is a better way to do that I'd love to hear.