### PR TITLE
No running process for target when restarting tasks with watch

### DIFF
--- a/tasks/shell.js
+++ b/tasks/shell.js
@@ -112,7 +112,10 @@ module.exports = function( grunt ) {
 
 
         proc.on('close', function (code) {
-            delete procs[target];
+            if (procs[target] && procs[target].pid === proc.pid) {
+                delete procs[target];
+            }
+            
             if ( _.isFunction( options.callback ) ) {
                 var stdOutString = stdOutBuf.toString('utf8', 0, stdOutPos),
                     stdErrString = stdOutBuf.toString('utf8', 0, stdErrPos);


### PR DESCRIPTION
Fixes a problem when shell is used in conjunction with a watch, for example to restart an externally running server with grunt-contrib-watch and tasks: ['shell:server:kill', 'shell:server']. That can work with options async: true and spawn:false (to maintain the state). 

When the server was restarted the second time, it fails with:
Fatal error: No running process for target:server

The handler for the 'close' event also removes the newly started server (timing issue) with the same target name but different PID. Fixed by checking the PID.