### PR TITLE
Changing Fatal error for something else.

### DIFF
--- a/tasks/shell.js
+++ b/tasks/shell.js
@@ -38,7 +38,8 @@ module.exports = function( grunt ) {
 
             proc = killable[target];
             if (!proc) {
-                grunt.fatal('No running process for target:' + target);
+                grunt.log.writeln('No running process for target:' + target);
+                return;
             }
             grunt.verbose.writeln('Killing process for target: ' + target + ' (pid = ' + proc.pid + ')');
 
@@ -98,7 +99,7 @@ module.exports = function( grunt ) {
         // Store proc to be killed!
         if (options.canKill) {
             if (killable[target]) {
-                grunt.fatal('Process :' + target + ' already started.');
+                grunt.warn('Process :' + target + ' already started.');
             }
             killable[target] = proc;
         }


### PR DESCRIPTION
Fatal errors completely shuts down the build, without the change for the developer to force through it.  Using warn is much better. 

As for the :kill command, I simply added a log since it shouldn't kill or fail your build because it can't kill the process.  If the process errored out, it would of been caught by the event listener.  It could simply be that a script tries to make sure that the process is dead the the user ctrl+c, and if it's already dead, great!