### PR TITLE
Using sync-exec instead of execSync

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "grunt": ">=0.4.x",
-    "execSync": "~1.0.1-pre"
+    "sync-exec": "^0.4.0"
   },
   "devDependencies": {
     "grunt-cli": "~0.1.9",

--- a/tasks/shell.js
+++ b/tasks/shell.js
@@ -17,7 +17,7 @@ module.exports = function( grunt ) {
     grunt.registerMultiTask( 'shell', 'Run shell commands', function() {
 
         var cp = require('child_process');
-        var execSync = require('execSync');
+        var execSync = require('sync-exec');
         var proc;
 
         var options = this.options({stdout: true, stderr: true, failOnError: true, canKill: true});


### PR DESCRIPTION
Dropping execSync dependency (package no longer maintained) in favor of
sync-exec