### PR TITLE
Add SIGINT handler that kills child process

### DIFF
--- a/tasks/shell.js
+++ b/tasks/shell.js
@@ -162,10 +162,6 @@ module.exports = function( grunt ) {
     });
 
     process.on('SIGINT', function () {
-        _.forEach(killable, function (proc, key, collection) {
-            killPid(proc.pid);
-            delete collection[key];
-        });
         process.exit();
     });
 

--- a/tasks/shell.js
+++ b/tasks/shell.js
@@ -25,11 +25,11 @@ module.exports = function( grunt ) {
         var target = this.target;
         var file, args, opts;
         var cmd = data.command;
-        
+
         if (cmd === undefined) {
             throw new Error('`command` required');
         }
-        
+
         cmd = grunt.template.process(typeof cmd === 'function' ? cmd.apply(grunt, arguments) : cmd);
 
         grunt.verbose.writeflags(options, 'Options');
@@ -156,9 +156,17 @@ module.exports = function( grunt ) {
 
     process.on('exit', function () {
         _.forEach(killable, function (proc, key, collection) {
-            proc.kill();
+            killPid(proc.pid);
             delete collection[key];
         });
+    });
+
+    process.on('SIGINT', function () {
+        _.forEach(killable, function (proc, key, collection) {
+            killPid(proc.pid);
+            delete collection[key];
+        });
+        process.exit();
     });
 
     function killPid(pid) {


### PR DESCRIPTION
The SIGINT handler and the exit handler also use the killPid function to reliably kill child process without leaving orphans (See also https://github.com/cri5ti/grunt-shell-spawn/pull/18)